### PR TITLE
feat: Add dynamic layout and fit mode options

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,10 +1,10 @@
 import tkinter as tk
-from tkinter import filedialog, messagebox
+from tkinter import ttk, filedialog, messagebox
 from reportlab.pdfgen import canvas
 from reportlab.lib.pagesizes import A4
 from reportlab.lib.units import cm
 from reportlab.lib.utils import ImageReader
-from PIL import Image
+from PIL import Image, ImageOps
 
 # Global variable to store image paths
 image_paths = []
@@ -15,34 +15,39 @@ def upload_files():
     stores their paths, and enables the PDF generation button.
     """
     global image_paths
-    # Open file dialog
     file_paths = filedialog.askopenfilenames(
         title="Seleccionar imágenes",
-        filetypes=(
-            ("Archivos de imagen", "*.jpg *.jpeg *.png"),
-            ("Todos los archivos", "*.*")
-        )
+        filetypes=(("Archivos de imagen", "*.jpg *.jpeg *.png"), ("Todos los archivos", "*.*"))
     )
-
     if file_paths:
         image_paths = list(file_paths)
-        print("Archivos seleccionados:")
-        for path in image_paths:
-            print(path)
-        # Enable the generate button if images are selected
+        print(f"{len(image_paths)} archivos seleccionados.")
         generate_button.config(state=tk.NORMAL)
     else:
-        # Disable if no files are selected
         image_paths = []
         generate_button.config(state=tk.DISABLED)
 
 def generate_pdf():
     """
-    Generates a PDF with the selected images arranged in a 2x2 grid.
+    Generates a PDF with the selected images based on the chosen layout and fit mode.
     """
     if not image_paths:
         messagebox.showinfo("Información", "No hay imágenes seleccionadas para generar el PDF.")
         return
+
+    # Get selected options from UI
+    layout_choice = layout_var.get()
+    fit_mode = fit_mode_var.get()
+
+    # Define layout configurations
+    layout_configs = {
+        "1 por hoja": (1, 1),
+        "2 por hoja": (1, 2), # Changed to 1 row, 2 cols for landscape-like feel
+        "4 por hoja (2x2)": (2, 2),
+        "6 por hoja (2x3)": (2, 3)
+    }
+    rows, cols = layout_configs[layout_choice]
+    chunk_size = rows * cols
 
     save_path = filedialog.asksaveasfilename(
         defaultextension=".pdf",
@@ -57,34 +62,45 @@ def generate_pdf():
         c = canvas.Canvas(save_path, pagesize=A4)
         width, height = A4
 
-        # Define margins and quadrant dimensions
+        # Define margins and calculate cell dimensions
         margin = 1 * cm
-        quadrant_width = (width - 2 * margin) / 2
-        quadrant_height = (height - 2 * margin) / 2
+        cell_width = (width - 2 * margin) / cols
+        cell_height = (height - 2 * margin) / rows
 
-        # Quadrant bottom-left starting positions (from bottom to top)
-        positions = [
-            (margin, margin),  # Bottom-left
-            (margin + quadrant_width, margin),  # Bottom-right
-            (margin, margin + quadrant_height),  # Top-left
-            (margin + quadrant_width, margin + quadrant_height),  # Top-right
-        ]
+        # Process images in chunks
+        for i in range(0, len(image_paths), chunk_size):
+            chunk = image_paths[i:i+chunk_size]
 
-        # Process images in chunks of 4
-        for i in range(0, len(image_paths), 4):
-            chunk = image_paths[i:i+4]
-
-            # Add a new page for each new chunk of images
             if i > 0:
                 c.showPage()
 
-            # Draw the 4 images on the current page
+            # Generate positions for the current page's grid
+            positions = []
+            for row in range(rows):
+                for col in range(cols):
+                    # Calculate bottom-left corner of the cell
+                    pos_x = margin + col * cell_width
+                    pos_y = margin + (rows - 1 - row) * cell_height
+                    positions.append((pos_x, pos_y))
+
+            # Draw the images in the current chunk
             for j, img_path in enumerate(chunk):
                 pos_x, pos_y = positions[j]
-                # Draw image fitting in the quadrant
-                c.drawImage(ImageReader(img_path), pos_x, pos_y,
-                            width=quadrant_width, height=quadrant_height,
-                            preserveAspectRatio=True, anchor='c')
+
+                # Logic for fit modes
+                if fit_mode == "Ajustar":
+                    # "Fit" mode: preserve aspect ratio, leave borders
+                    c.drawImage(ImageReader(img_path), pos_x, pos_y,
+                                width=cell_width, height=cell_height,
+                                preserveAspectRatio=True, anchor='c')
+                elif fit_mode == "Rellenar":
+                    # "Fill" mode: crop image to fill the cell
+                    img = Image.open(img_path)
+                    # Use ImageOps.fit to scale and crop the image
+                    cropped_img = ImageOps.fit(img, (int(cell_width), int(cell_height)),
+                                               method=Image.Resampling.LANCZOS)
+                    c.drawImage(ImageReader(cropped_img), pos_x, pos_y,
+                                width=cell_width, height=cell_height)
 
         c.save()
         messagebox.showinfo("Éxito", f"PDF guardado exitosamente en:\n{save_path}")
@@ -92,24 +108,54 @@ def generate_pdf():
     except Exception as e:
         messagebox.showerror("Error", f"Ocurrió un error al generar el PDF:\n{e}")
 
+
 # --- UI Setup ---
 root = tk.Tk()
-root.title("Impresión Maestra - v1.0")
+root.title("Impresión Maestra - v1.1")
 root.geometry("800x600")
 
-# --- Widgets ---
-# Frame for buttons
-button_frame = tk.Frame(root)
-button_frame.pack(pady=10)
+# --- Main container frame ---
+main_frame = tk.Frame(root, padx=10, pady=10)
+main_frame.pack(fill=tk.BOTH, expand=True)
+
+# --- Options Frame ---
+options_frame = ttk.LabelFrame(main_frame, text="Opciones de Diseño", padding=(10, 5))
+options_frame.pack(fill=tk.X, pady=5)
+
+# Layout selection
+layout_label = ttk.Label(options_frame, text="Diseño por Hoja:")
+layout_label.grid(row=0, column=0, padx=5, pady=5, sticky="w")
+layout_var = tk.StringVar()
+layout_options = ["1 por hoja", "2 por hoja", "4 por hoja (2x2)", "6 por hoja (2x3)"]
+layout_combo = ttk.Combobox(options_frame, textvariable=layout_var, values=layout_options, state="readonly")
+layout_combo.grid(row=0, column=1, padx=5, pady=5, sticky="ew")
+layout_combo.set("4 por hoja (2x2)")
+
+# Fit mode selection
+fit_mode_label = ttk.Label(options_frame, text="Modo de Ajuste:")
+fit_mode_label.grid(row=1, column=0, padx=5, pady=5, sticky="w")
+fit_mode_var = tk.StringVar()
+fit_mode_frame = ttk.Frame(options_frame)
+fit_mode_frame.grid(row=1, column=1, padx=5, pady=5, sticky="ew")
+fit_radio_fit = ttk.Radiobutton(fit_mode_frame, text="Ajustar (con bordes)", variable=fit_mode_var, value="Ajustar")
+fit_radio_fill = ttk.Radiobutton(fit_mode_frame, text="Rellenar (recorte)", variable=fit_mode_var, value="Rellenar")
+fit_radio_fit.pack(side=tk.LEFT, expand=True)
+fit_radio_fill.pack(side=tk.LEFT, expand=True)
+fit_mode_var.set("Ajustar")
+
+options_frame.columnconfigure(1, weight=1)
+
+# --- Action Buttons Frame ---
+action_frame = ttk.LabelFrame(main_frame, text="Acciones", padding=(10, 5))
+action_frame.pack(fill=tk.X, pady=5)
 
 # Load Images Button
-load_button = tk.Button(button_frame, text="Cargar Imágenes", command=upload_files)
-load_button.pack(side=tk.LEFT, padx=5)
+load_button = ttk.Button(action_frame, text="Cargar Imágenes", command=upload_files)
+load_button.pack(side=tk.LEFT, padx=5, pady=5)
 
 # Generate PDF Button
-generate_button = tk.Button(button_frame, text="Generar PDF", command=generate_pdf, state=tk.DISABLED)
-generate_button.pack(side=tk.LEFT, padx=5)
-
+generate_button = ttk.Button(action_frame, text="Generar PDF", command=generate_pdf, state=tk.DISABLED)
+generate_button.pack(side=tk.LEFT, padx=5, pady=5)
 
 # Start the main loop
 root.mainloop()


### PR DESCRIPTION
This commit enhances the "Impresión Maestra" application by adding more control over the PDF layout.

The changes include:
- A dropdown menu (Combobox) allows users to select the number of images per page: "1 por hoja", "2 por hoja", "4 por hoja (2x2)", or "6 por hoja (2x3)".
- Radio buttons provide two image fit modes: "Ajustar (con bordes)" (Fit) and "Rellenar (recorte inteligente)" (Fill).
- The `generate_pdf` function is now fully dynamic, calculating the grid layout and cell positions based on the user's selection.
- The "Rellenar" mode is implemented using `Pillow.ImageOps.fit` to scale and crop images to fill their designated cells perfectly.
- The UI has been reorganized using `ttk` widgets for a more modern look.