### PR TITLE
feat: Add Mosaic layout mode with bin packing

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ from reportlab.lib.pagesizes import A4
 from reportlab.lib.units import cm
 from reportlab.lib.utils import ImageReader
 from PIL import Image, ImageOps
+import rectpack
 
 # Global variable to store image paths
 image_paths = []
@@ -27,6 +28,50 @@ def upload_files():
         image_paths = []
         generate_button.config(state=tk.DISABLED)
 
+def run_mosaic_layout(image_paths, save_path):
+    """
+    Generates a PDF using a bin-packing algorithm for a mosaic layout.
+    """
+    try:
+        margin = 1 * cm
+        page_width, page_height = A4
+        bin_width = page_width - 2 * margin
+        bin_height = page_height - 2 * margin
+
+        # 1. Read image dimensions and associate with path
+        images_data = []
+        for path in image_paths:
+            with Image.open(path) as img:
+                w, h = img.size
+                images_data.append({'width': w, 'height': h, 'path': path})
+
+        # 2. Use rectpack to find optimal positions
+        packer = rectpack.newPacker(pack_algo=rectpack.MaxRectsBl, sort_algo=rectpack.SORT_AREA)
+
+        for img in images_data:
+            packer.add_rect(img['width'], img['height'], rid=img['path'])
+
+        packer.add_bin(bin_width, bin_height, count=float('inf'))
+        packer.pack()
+
+        # 3. Generate the PDF from the packed result
+        c = canvas.Canvas(save_path, pagesize=A4)
+
+        for i, abin in enumerate(packer):
+            if i > 0:
+                c.showPage()
+
+            for rect in abin:
+                x = margin + rect.x
+                y = margin + rect.y
+                c.drawImage(rect.rid, x, y, width=rect.width, height=rect.height)
+
+        c.save()
+        messagebox.showinfo("Éxito", f"PDF en modo Mosaico guardado en:\n{save_path}")
+
+    except Exception as e:
+        messagebox.showerror("Error", f"Ocurrió un error en el modo Mosaico:\n{e}")
+
 def generate_pdf():
     """
     Generates a PDF with the selected images based on the chosen layout and fit mode.
@@ -35,19 +80,7 @@ def generate_pdf():
         messagebox.showinfo("Información", "No hay imágenes seleccionadas para generar el PDF.")
         return
 
-    # Get selected options from UI
     layout_choice = layout_var.get()
-    fit_mode = fit_mode_var.get()
-
-    # Define layout configurations
-    layout_configs = {
-        "1 por hoja": (1, 1),
-        "2 por hoja": (1, 2), # Changed to 1 row, 2 cols for landscape-like feel
-        "4 por hoja (2x2)": (2, 2),
-        "6 por hoja (2x3)": (2, 3)
-    }
-    rows, cols = layout_configs[layout_choice]
-    chunk_size = rows * cols
 
     save_path = filedialog.asksaveasfilename(
         defaultextension=".pdf",
@@ -56,82 +89,75 @@ def generate_pdf():
     )
 
     if not save_path:
-        return  # User cancelled
+        return
 
-    try:
-        c = canvas.Canvas(save_path, pagesize=A4)
-        width, height = A4
+    # --- Main logic branch ---
+    if layout_choice == "Mosaico (Ahorro de papel)":
+        run_mosaic_layout(image_paths, save_path)
+    else:
+        # --- Grid-based layout logic ---
+        try:
+            fit_mode = fit_mode_var.get()
+            layout_configs = {
+                "1 por hoja": (1, 1), "2 por hoja": (1, 2),
+                "4 por hoja (2x2)": (2, 2), "6 por hoja (2x3)": (2, 3)
+            }
+            rows, cols = layout_configs[layout_choice]
+            chunk_size = rows * cols
 
-        # Define margins and calculate cell dimensions
-        margin = 1 * cm
-        cell_width = (width - 2 * margin) / cols
-        cell_height = (height - 2 * margin) / rows
+            c = canvas.Canvas(save_path, pagesize=A4)
+            width, height = A4
+            margin = 1 * cm
+            cell_width = (width - 2 * margin) / cols
+            cell_height = (height - 2 * margin) / rows
 
-        # Process images in chunks
-        for i in range(0, len(image_paths), chunk_size):
-            chunk = image_paths[i:i+chunk_size]
+            for i in range(0, len(image_paths), chunk_size):
+                chunk = image_paths[i:i+chunk_size]
+                if i > 0:
+                    c.showPage()
 
-            if i > 0:
-                c.showPage()
+                positions = []
+                for row in range(rows):
+                    for col in range(cols):
+                        pos_x = margin + col * cell_width
+                        pos_y = margin + (rows - 1 - row) * cell_height
+                        positions.append((pos_x, pos_y))
 
-            # Generate positions for the current page's grid
-            positions = []
-            for row in range(rows):
-                for col in range(cols):
-                    # Calculate bottom-left corner of the cell
-                    pos_x = margin + col * cell_width
-                    pos_y = margin + (rows - 1 - row) * cell_height
-                    positions.append((pos_x, pos_y))
+                for j, img_path in enumerate(chunk):
+                    pos_x, pos_y = positions[j]
+                    if fit_mode == "Ajustar":
+                        c.drawImage(ImageReader(img_path), pos_x, pos_y, width=cell_width, height=cell_height, preserveAspectRatio=True, anchor='c')
+                    elif fit_mode == "Rellenar":
+                        img = Image.open(img_path)
+                        cropped_img = ImageOps.fit(img, (int(cell_width), int(cell_height)), method=Image.Resampling.LANCZOS)
+                        c.drawImage(ImageReader(cropped_img), pos_x, pos_y, width=cell_width, height=cell_height)
 
-            # Draw the images in the current chunk
-            for j, img_path in enumerate(chunk):
-                pos_x, pos_y = positions[j]
+            c.save()
+            messagebox.showinfo("Éxito", f"PDF guardado exitosamente en:\n{save_path}")
 
-                # Logic for fit modes
-                if fit_mode == "Ajustar":
-                    # "Fit" mode: preserve aspect ratio, leave borders
-                    c.drawImage(ImageReader(img_path), pos_x, pos_y,
-                                width=cell_width, height=cell_height,
-                                preserveAspectRatio=True, anchor='c')
-                elif fit_mode == "Rellenar":
-                    # "Fill" mode: crop image to fill the cell
-                    img = Image.open(img_path)
-                    # Use ImageOps.fit to scale and crop the image
-                    cropped_img = ImageOps.fit(img, (int(cell_width), int(cell_height)),
-                                               method=Image.Resampling.LANCZOS)
-                    c.drawImage(ImageReader(cropped_img), pos_x, pos_y,
-                                width=cell_width, height=cell_height)
-
-        c.save()
-        messagebox.showinfo("Éxito", f"PDF guardado exitosamente en:\n{save_path}")
-
-    except Exception as e:
-        messagebox.showerror("Error", f"Ocurrió un error al generar el PDF:\n{e}")
+        except Exception as e:
+            messagebox.showerror("Error", f"Ocurrió un error al generar el PDF:\n{e}")
 
 
 # --- UI Setup ---
 root = tk.Tk()
-root.title("Impresión Maestra - v1.1")
+root.title("Impresión Maestra - v1.2") # Version bump
 root.geometry("800x600")
 
-# --- Main container frame ---
 main_frame = tk.Frame(root, padx=10, pady=10)
 main_frame.pack(fill=tk.BOTH, expand=True)
 
-# --- Options Frame ---
 options_frame = ttk.LabelFrame(main_frame, text="Opciones de Diseño", padding=(10, 5))
 options_frame.pack(fill=tk.X, pady=5)
 
-# Layout selection
 layout_label = ttk.Label(options_frame, text="Diseño por Hoja:")
 layout_label.grid(row=0, column=0, padx=5, pady=5, sticky="w")
 layout_var = tk.StringVar()
-layout_options = ["1 por hoja", "2 por hoja", "4 por hoja (2x2)", "6 por hoja (2x3)"]
+layout_options = ["1 por hoja", "2 por hoja", "4 por hoja (2x2)", "6 por hoja (2x3)", "Mosaico (Ahorro de papel)"]
 layout_combo = ttk.Combobox(options_frame, textvariable=layout_var, values=layout_options, state="readonly")
 layout_combo.grid(row=0, column=1, padx=5, pady=5, sticky="ew")
 layout_combo.set("4 por hoja (2x2)")
 
-# Fit mode selection
 fit_mode_label = ttk.Label(options_frame, text="Modo de Ajuste:")
 fit_mode_label.grid(row=1, column=0, padx=5, pady=5, sticky="w")
 fit_mode_var = tk.StringVar()
@@ -145,17 +171,13 @@ fit_mode_var.set("Ajustar")
 
 options_frame.columnconfigure(1, weight=1)
 
-# --- Action Buttons Frame ---
 action_frame = ttk.LabelFrame(main_frame, text="Acciones", padding=(10, 5))
 action_frame.pack(fill=tk.X, pady=5)
 
-# Load Images Button
 load_button = ttk.Button(action_frame, text="Cargar Imágenes", command=upload_files)
 load_button.pack(side=tk.LEFT, padx=5, pady=5)
 
-# Generate PDF Button
 generate_button = ttk.Button(action_frame, text="Generar PDF", command=generate_pdf, state=tk.DISABLED)
 generate_button.pack(side=tk.LEFT, padx=5, pady=5)
 
-# Start the main loop
 root.mainloop()


### PR DESCRIPTION
This commit introduces an advanced "Mosaico (Ahorro de papel)" layout mode to the application.

Key changes:
- A new "Mosaico" option is added to the layout selection dropdown.
- When selected, a 2D bin packing algorithm is used to arrange images efficiently on A4 pages, minimizing wasted space.
- The `rectpack` library has been added as a dependency to handle the complex packing algorithm.
- A new function, `run_mosaic_layout`, encapsulates the logic for this mode.
- The application version has been updated to v1.2.