### PR TITLE
feat: Add dynamic layout preview panel

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,248 +4,212 @@ from reportlab.pdfgen import canvas
 from reportlab.lib.pagesizes import A4
 from reportlab.lib.units import cm
 from reportlab.lib.utils import ImageReader
-from PIL import Image, ImageOps, ImageTk
+from PIL import Image, ImageOps
 import rectpack
 import os
 
 # Global variables
 image_paths = []
-thumbnail_references = [] # To prevent garbage collection
+paper_dims = {} # To store on-screen paper dimensions
 
 def upload_files():
     """
-    Opens a file dialog, loads images, and displays thumbnails in the preview panel.
+    Opens a file dialog to select image paths and triggers a preview update.
     """
-    global image_paths, thumbnail_references
-
+    global image_paths
     file_paths_tuple = filedialog.askopenfilenames(
         title="Seleccionar imágenes",
         filetypes=(("Archivos de imagen", "*.jpg *.jpeg *.png"), ("Todos los archivos", "*.*"))
     )
-
-    # 1. Clear previous state
-    for widget in scrollable_frame.winfo_children():
-        widget.destroy()
-    thumbnail_references.clear()
-
     if file_paths_tuple:
         image_paths = list(file_paths_tuple)
-
-        # 2. Display new thumbnails in a grid
-        for i, path in enumerate(image_paths):
-            try:
-                img = Image.open(path)
-                img.thumbnail((100, 100))
-                photo_img = ImageTk.PhotoImage(img)
-
-                # 3. Keep a reference to avoid garbage collection
-                thumbnail_references.append(photo_img)
-
-                thumb_frame = ttk.Frame(scrollable_frame, padding=5)
-                img_label = ttk.Label(thumb_frame, image=photo_img)
-                img_label.pack()
-
-                filename = os.path.basename(path)
-                name_label = ttk.Label(thumb_frame, text=filename, wraplength=100, justify='center')
-                name_label.pack()
-
-                row, col = divmod(i, 4) # 4 columns
-                thumb_frame.grid(row=row, column=col, padx=5, pady=5)
-
-            except Exception as e:
-                print(f"Error loading thumbnail for {path}: {e}")
-
+        preview_button.config(state=tk.NORMAL)
         generate_button.config(state=tk.NORMAL)
+        update_preview()
     else:
-        # No files selected, ensure everything is cleared
         image_paths = []
+        preview_button.config(state=tk.DISABLED)
         generate_button.config(state=tk.DISABLED)
+        update_preview()
 
-def run_mosaic_layout(image_paths, save_path):
+# --- Layout Calculation Logic ---
+# (This section is unchanged from the previous step)
+def calculate_mosaic_layout(image_paths):
+    margin = 1 * cm
+    page_width, page_height = A4
+    bin_width = page_width - 2 * margin
+    bin_height = page_height - 2 * margin
+    images_data = [{'width': w, 'height': h, 'path': p}
+                   for p in image_paths for w, h in [Image.open(p).size]]
+    packer = rectpack.newPacker(pack_algo=rectpack.MaxRectsBl, sort_algo=rectpack.SORT_AREA, rotation=True)
+    for img in images_data:
+        packer.add_rect(img['width'], img['height'], rid=img['path'])
+    packer.add_bin(bin_width, bin_height, count=float('inf'))
+    packer.pack()
+    all_rids = {img['path'] for img in images_data}
+    packed_rids = {rect.rid for abin in packer for rect in abin}
+    unpacked_paths = list(all_rids - packed_rids)
+    return packer, unpacked_paths
+
+def calculate_grid_layout(image_paths, layout_choice):
+    layout_configs = {"1 por hoja": (1, 1), "2 por hoja": (1, 2), "4 por hoja (2x2)": (2, 2), "6 por hoja (2x3)": (2, 3)}
+    rows, cols = layout_configs[layout_choice]
+    chunk_size = rows * cols
+    pages = [image_paths[i:i + chunk_size] for i in range(0, len(image_paths), chunk_size)]
+    return pages
+
+# --- PDF Generation / Preview Logic ---
+def update_preview():
     """
-    Generates a PDF using a bin-packing algorithm for a mosaic layout.
+    Updates the preview canvas with a visual representation of the layout.
     """
-    try:
-        margin = 1 * cm
-        page_width, page_height = A4
-        bin_width = page_width - 2 * margin
-        bin_height = page_height - 2 * margin
-
-        # 1. Read image dimensions and associate with path
-        images_data = []
-        for path in image_paths:
-            with Image.open(path) as img:
-                w, h = img.size
-                images_data.append({'width': w, 'height': h, 'path': path})
-
-        # 2. Use rectpack to find optimal positions, with rotation enabled
-        packer = rectpack.newPacker(pack_algo=rectpack.MaxRectsBl, sort_algo=rectpack.SORT_AREA, rotation=True)
-
-        for img in images_data:
-            packer.add_rect(img['width'], img['height'], rid=img['path'])
-
-        packer.add_bin(bin_width, bin_height, count=float('inf'))
-        packer.pack()
-
-        # 3. Check for unpacked images
-        all_rids = {img['path'] for img in images_data}
-        packed_rids = {rect.rid for abin in packer for rect in abin}
-        unpacked_rids = all_rids - packed_rids
-
-        if unpacked_rids:
-            msg = "Las siguientes imágenes son demasiado grandes para caber en una página y no se incluirán:\n\n"
-            for rid in unpacked_rids:
-                msg += f"- {os.path.basename(rid)}\n"
-            messagebox.showwarning("Imágenes Grandes Omitidas", msg)
-
-        if not any(packer):
-            messagebox.showerror("Error", "No se pudo empaquetar ninguna imagen. El PDF no será generado.")
-            return
-
-        # 4. Generate the PDF from the packed result
-        c = canvas.Canvas(save_path, pagesize=A4)
-
-        for i, abin in enumerate(packer):
-            if i > 0:
-                c.showPage()
-
-            for rect in abin:
-                # Load the original image
-                img = Image.open(rect.rid)
-                # Rotate it if the packer decided to
-                if rect.rotated:
-                    img = img.rotate(90, expand=True)
-
-                # Define position and draw the (potentially rotated) image
-                x = margin + rect.x
-                y = margin + rect.y
-                c.drawImage(ImageReader(img), x, y, width=rect.width, height=rect.height)
-
-        c.save()
-        messagebox.showinfo("Éxito", f"PDF en modo Mosaico guardado en:\n{save_path}")
-
-    except Exception as e:
-        messagebox.showerror("Error", f"Ocurrió un error en el modo Mosaico:\n{e}")
-
-def generate_pdf():
-    """
-    Generates a PDF with the selected images based on the chosen layout and fit mode.
-    """
-    if not image_paths:
-        messagebox.showinfo("Información", "No hay imágenes seleccionadas para generar el PDF.")
+    preview_canvas.delete("layout_item")
+    if not image_paths or not paper_dims:
         return
 
     layout_choice = layout_var.get()
 
-    save_path = filedialog.asksaveasfilename(
-        defaultextension=".pdf",
-        filetypes=[("Archivos PDF", "*.pdf"), ("Todos los archivos", "*.*")],
-        title="Guardar PDF como..."
-    )
+    x0, y0, paper_w_px, paper_h_px = paper_dims['x'], paper_dims['y'], paper_dims['w'], paper_dims['h']
+    A4_w_pt, A4_h_pt = A4
+    scale = paper_w_px / A4_w_pt
+    margin_pt = 1 * cm
 
+    if layout_choice == "Mosaico (Ahorro de papel)":
+        try:
+            packer, _ = calculate_mosaic_layout(image_paths)
+            if any(packer):
+                first_page = packer[0]
+                for rect in first_page:
+                    px = x0 + (margin_pt + rect.x) * scale
+                    py = y0 + paper_h_px - (margin_pt + rect.y + rect.height) * scale
+                    pw = rect.width * scale
+                    ph = rect.height * scale
+                    preview_canvas.create_rectangle(px, py, px + pw, py + ph, outline="blue", fill="lightblue", tags="layout_item")
+                    preview_canvas.create_text(px + 4, py + 4, text=os.path.basename(rect.rid), anchor="nw", font=("Arial", 7), tags="layout_item")
+        except Exception as e:
+            messagebox.showerror("Error de Previsualización", f"No se pudo previsualizar el modo mosaico:\n{e}")
+    else:
+        pages = calculate_grid_layout(image_paths, layout_choice)
+        if not pages: return
+
+        layout_configs = {"1 por hoja": (1, 1), "2 por hoja": (1, 2), "4 por hoja (2x2)": (2, 2), "6 por hoja (2x3)": (2, 3)}
+        rows, cols = layout_configs[layout_choice]
+        cell_width_pt = (A4_w_pt - 2 * margin_pt) / cols
+        cell_height_pt = (A4_h_pt - 2 * margin_pt) / rows
+
+        first_page_paths = pages[0]
+        for i, path in enumerate(first_page_paths):
+            row, col = divmod(i, cols)
+
+            x_pt = margin_pt + col * cell_width_pt
+            y_pt = margin_pt + (rows - 1 - row) * cell_height_pt
+
+            px = x0 + x_pt * scale
+            py = y0 + paper_h_px - (y_pt + cell_height_pt) * scale
+            pw = cell_width_pt * scale
+            ph = cell_height_pt * scale
+
+            preview_canvas.create_rectangle(px, py, px + pw, py + ph, outline="green", fill="lightgreen", tags="layout_item")
+            preview_canvas.create_text(px + 4, py + 4, text=os.path.basename(path), anchor="nw", font=("Arial", 7), tags="layout_item")
+
+def generate_pdf():
+    if not image_paths:
+        messagebox.showinfo("Información", "No hay imágenes seleccionadas.")
+        return
+    save_path = filedialog.asksaveasfilename(defaultextension=".pdf", filetypes=[("Archivos PDF", "*.pdf"), ("Todos los archivos", "*.*")], title="Guardar PDF como...")
     if not save_path:
         return
-
-    # --- Main logic branch ---
-    if layout_choice == "Mosaico (Ahorro de papel)":
-        run_mosaic_layout(image_paths, save_path)
-    else:
-        # --- Grid-based layout logic ---
-        try:
+    try:
+        layout_choice = layout_var.get()
+        if layout_choice == "Mosaico (Ahorro de papel)":
+            packed_pages, unpacked = calculate_mosaic_layout(image_paths)
+            if unpacked:
+                msg = "Imágenes omitidas por ser demasiado grandes:\n\n" + "\n".join(f"- {os.path.basename(p)}" for p in unpacked)
+                messagebox.showwarning("Imágenes Grandes Omitidas", msg)
+            if not any(packed_pages):
+                messagebox.showerror("Error", "No se pudo empaquetar ninguna imagen.")
+                return
+            draw_mosaic_pdf(packed_pages, save_path)
+        else: # Grid modes
+            pages = calculate_grid_layout(image_paths, layout_choice)
             fit_mode = fit_mode_var.get()
-            layout_configs = {
-                "1 por hoja": (1, 1), "2 por hoja": (1, 2),
-                "4 por hoja (2x2)": (2, 2), "6 por hoja (2x3)": (2, 3)
-            }
-            rows, cols = layout_configs[layout_choice]
-            chunk_size = rows * cols
+            draw_grid_pdf(pages, layout_choice, fit_mode, save_path)
+    except Exception as e:
+        messagebox.showerror("Error", f"Ocurrió un error inesperado:\n{e}")
 
-            c = canvas.Canvas(save_path, pagesize=A4)
-            width, height = A4
-            margin = 1 * cm
-            cell_width = (width - 2 * margin) / cols
-            cell_height = (height - 2 * margin) / rows
+def draw_mosaic_pdf(packer, save_path):
+    margin = 1 * cm
+    c = canvas.Canvas(save_path, pagesize=A4)
+    for i, abin in enumerate(packer):
+        if i > 0: c.showPage()
+        for rect in abin:
+            img = Image.open(rect.rid)
+            if rect.rotated:
+                img = img.rotate(90, expand=True)
+            x = margin + rect.x
+            y = margin + rect.y
+            c.drawImage(ImageReader(img), x, y, width=rect.width, height=rect.height)
+    c.save()
+    messagebox.showinfo("Éxito", f"PDF en modo Mosaico guardado en:\n{save_path}")
 
-            for i in range(0, len(image_paths), chunk_size):
-                chunk = image_paths[i:i+chunk_size]
-                if i > 0:
-                    c.showPage()
-
-                positions = []
-                for row in range(rows):
-                    for col in range(cols):
-                        pos_x = margin + col * cell_width
-                        pos_y = margin + (rows - 1 - row) * cell_height
-                        positions.append((pos_x, pos_y))
-
-                for j, img_path in enumerate(chunk):
-                    pos_x, pos_y = positions[j]
-                    if fit_mode == "Ajustar":
-                        c.drawImage(ImageReader(img_path), pos_x, pos_y, width=cell_width, height=cell_height, preserveAspectRatio=True, anchor='c')
-                    elif fit_mode == "Rellenar":
-                        img = Image.open(img_path)
-                        cropped_img = ImageOps.fit(img, (int(cell_width), int(cell_height)), method=Image.Resampling.LANCZOS)
-                        c.drawImage(ImageReader(cropped_img), pos_x, pos_y, width=cell_width, height=cell_height)
-
-            c.save()
-            messagebox.showinfo("Éxito", f"PDF guardado exitosamente en:\n{save_path}")
-
-        except Exception as e:
-            messagebox.showerror("Error", f"Ocurrió un error al generar el PDF:\n{e}")
-
+def draw_grid_pdf(pages, layout_choice, fit_mode, save_path):
+    layout_configs = {"1 por hoja": (1, 1), "2 por hoja": (1, 2), "4 por hoja (2x2)": (2, 2), "6 por hoja (2x3)": (2, 3)}
+    rows, cols = layout_configs[layout_choice]
+    c = canvas.Canvas(save_path, pagesize=A4)
+    width, height = A4
+    margin = 1 * cm
+    cell_width = (width - 2 * margin) / cols
+    cell_height = (height - 2 * margin) / rows
+    for i, page_chunk in enumerate(pages):
+        if i > 0: c.showPage()
+        positions = [(margin + col * cell_width, margin + (rows - 1 - row) * cell_height) for row in range(rows) for col in range(cols)]
+        for j, img_path in enumerate(page_chunk):
+            pos_x, pos_y = positions[j]
+            if fit_mode == "Ajustar":
+                c.drawImage(ImageReader(img_path), pos_x, pos_y, width=cell_width, height=cell_height, preserveAspectRatio=True, anchor='c')
+            elif fit_mode == "Rellenar":
+                img = Image.open(img_path)
+                cropped_img = ImageOps.fit(img, (int(cell_width), int(cell_height)), method=Image.Resampling.LANCZOS)
+                c.drawImage(ImageReader(cropped_img), pos_x, pos_y, width=cell_width, height=cell_height)
+    c.save()
+    messagebox.showinfo("Éxito", f"PDF guardado exitosamente en:\n{save_path}")
 
 # --- UI Setup ---
 root = tk.Tk()
-root.title("Impresión Maestra - v1.2")
-root.geometry("1024x768") # Increased size for the new layout
+root.title("Impresión Maestra - v1.3")
+root.geometry("1024x768")
 
-# Main container with two panels
 main_container = ttk.Frame(root)
 main_container.pack(fill=tk.BOTH, expand=True, padx=10, pady=10)
 
-# Left panel for controls
 controls_panel = ttk.Frame(main_container, width=320)
 controls_panel.pack(side=tk.LEFT, fill=tk.Y, padx=(0, 10))
-controls_panel.pack_propagate(False) # Prevent panel from shrinking
+controls_panel.pack_propagate(False)
 
-# Right panel for preview
-preview_panel = ttk.LabelFrame(main_container, text="Previsualización")
+preview_panel = ttk.LabelFrame(main_container, text="Previsualización del Diseño (Página 1)")
 preview_panel.pack(side=tk.RIGHT, fill=tk.BOTH, expand=True)
 
-# --- Create Scrollable Canvas for Thumbnails ---
-preview_canvas = tk.Canvas(preview_panel, borderwidth=0)
-scrollbar = ttk.Scrollbar(preview_panel, orient="vertical", command=preview_canvas.yview)
-scrollable_frame = ttk.Frame(preview_canvas)
-
-scrollable_frame.bind(
-    "<Configure>",
-    lambda e: preview_canvas.configure(
-        scrollregion=preview_canvas.bbox("all")
-    )
-)
-
-canvas_frame = preview_canvas.create_window((0, 0), window=scrollable_frame, anchor="nw")
-preview_canvas.configure(yscrollcommand=scrollbar.set)
-
-# Add mouse wheel scrolling
-def _on_mouse_wheel(event):
-    # Cross-platform mouse wheel scrolling
-    if event.num == 5 or event.delta < 0:
-        preview_canvas.yview_scroll(1, "units")
-    elif event.num == 4 or event.delta > 0:
-        preview_canvas.yview_scroll(-1, "units")
-
-# Bind mouse wheel to the canvas for scrolling
-preview_canvas.bind_all("<MouseWheel>", _on_mouse_wheel)
-preview_canvas.bind_all("<Button-4>", _on_mouse_wheel)
-preview_canvas.bind_all("<Button-5>", _on_mouse_wheel)
-
-# Pack the canvas and scrollbar
+preview_canvas = tk.Canvas(preview_panel, bg="lightgrey")
 preview_canvas.pack(side="left", fill="both", expand=True)
-scrollbar.pack(side="right", fill="y")
 
+def redraw_paper(event):
+    global paper_dims
+    preview_canvas.delete("all")
+    canvas_w, canvas_h = event.width, event.height
+    ar = 210 / 297
+    paper_w = min(canvas_w * 0.95, (canvas_h * 0.95) * ar)
+    paper_h = paper_w / ar
+    if paper_h > canvas_h * 0.95:
+        paper_h = canvas_h * 0.95
+        paper_w = paper_h * ar
+    x0 = (canvas_w - paper_w) / 2
+    y0 = (canvas_h - paper_h) / 2
+    preview_canvas.create_rectangle(x0, y0, x0 + paper_w, y0 + paper_h, fill="white", tags="paper")
+    paper_dims = {'x': x0, 'y': y0, 'w': paper_w, 'h': paper_h}
+    update_preview()
 
-# --- Populate Controls Panel ---
+preview_canvas.bind("<Configure>", redraw_paper)
+
 options_frame = ttk.LabelFrame(controls_panel, text="Opciones de Diseño", padding=(10, 5))
 options_frame.pack(fill=tk.X, pady=5)
 
@@ -275,8 +239,10 @@ action_frame.pack(fill=tk.X, pady=5)
 load_button = ttk.Button(action_frame, text="Cargar Imágenes", command=upload_files)
 load_button.pack(side=tk.LEFT, padx=5, pady=5)
 
+preview_button = ttk.Button(action_frame, text="Actualizar Previsualización", command=update_preview, state=tk.DISABLED)
+preview_button.pack(side=tk.LEFT, padx=5, pady=5)
+
 generate_button = ttk.Button(action_frame, text="Generar PDF", command=generate_pdf, state=tk.DISABLED)
 generate_button.pack(side=tk.LEFT, padx=5, pady=5)
-
 
 root.mainloop()


### PR DESCRIPTION
This commit implements a major new feature: a dynamic preview panel that shows the final PDF layout.

Key changes:
- The core logic has been refactored to separate layout calculation from PDF drawing, making the application more modular.
- The UI has been updated to replace the previous thumbnail list with a single canvas that renders a preview of the first page of the document.
- A new 'Actualizar Previsualización' button triggers the calculation and drawing of placeholder rectangles onto the preview canvas.
- The preview automatically updates when loading new images or resizing the window.