### PR TITLE
feat: Add customizable borders for 'Fit' mode

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,8 @@
 import tkinter as tk
-from tkinter import ttk, filedialog, messagebox
+from tkinter import ttk, filedialog, messagebox, colorchooser
 from reportlab.pdfgen import canvas
-from reportlab.lib.pagesizes import A4, landscape
+from reportlab.lib.pagesizes import A4
+from reportlab.lib.colors import HexColor
 from reportlab.lib.units import cm
 from reportlab.lib.utils import ImageReader
 from PIL import Image, ImageOps, ImageTk
@@ -11,91 +12,36 @@ import os
 # Global variables
 image_paths = []
 paper_dims = {} # To store on-screen paper dimensions
+FIT_MODE_FIT = "fit"
+FIT_MODE_FILL = "fill"
 preview_pages = [] # To store the layout data for all pages
 current_preview_page_index = 0 # To track the current page in the preview
 
-def get_page_size():
+def upload_files():
     """
-    Returns the page dimensions (A4 or landscape A4) based on the UI selection.
-    """
-    if orientation_var.get() == "Horizontal":
-        return landscape(A4)
-    return A4
-
-def _handle_file_selection(replace_current: bool):
-    """
-    Internal logic for opening file dialog and updating the image list.
+    Opens a file dialog to select image paths and triggers a preview update.
     """
     global image_paths
-    title = "Seleccionar imágenes para cargar" if replace_current else "Seleccionar imágenes para añadir"
     file_paths_tuple = filedialog.askopenfilenames(
-        title=title,
+        title="Seleccionar imágenes",
         filetypes=(("Archivos de imagen", "*.jpg *.jpeg *.png"), ("Todos los archivos", "*.*"))
     )
-
-    if not file_paths_tuple:
-        # If replacing, a cancelled dialog means clearing the list.
-        if replace_current:
-            image_paths = []
-    else:
-        if replace_current:
-            image_paths = list(file_paths_tuple)
-        else:
-            # Ensure image_paths is a list before extending
-            if not isinstance(image_paths, list):
-                image_paths = []
-            image_paths.extend(list(file_paths_tuple))
-
-    # Update button states based on whether there are images
-    if image_paths:
+    if file_paths_tuple:
+        image_paths = list(file_paths_tuple)
         preview_button.config(state=tk.NORMAL)
         generate_button.config(state=tk.NORMAL)
+        update_preview()
     else:
+        image_paths = []
         preview_button.config(state=tk.DISABLED)
         generate_button.config(state=tk.DISABLED)
-
-    update_preview()
-
-def upload_files_replace():
-    """Action for the 'Cargar Imágenes' button."""
-    _handle_file_selection(replace_current=True)
-
-def upload_files_add():
-    """Action for the 'Añadir Imágenes' button."""
-    _handle_file_selection(replace_current=False)
+        update_preview()
 
 # --- Layout Calculation Logic ---
-def get_grid_dimensions():
-    """
-    Determines the grid dimensions (rows, cols) based on the layout selection.
-    This is the single source of truth for grid sizing.
-    """
-    layout_choice = layout_var.get()
-
-    if layout_choice == "Personalizado...":
-        try:
-            # Get values from spinboxes, ensure they are at least 1
-            rows = int(rows_var.get())
-            cols = int(cols_var.get())
-            return (rows if rows > 0 else 1, cols if cols > 0 else 1)
-        except (ValueError, tk.TclError):
-            return (1, 1)  # Default to 1x1 on error
-    else:
-        # The master dictionary for all predefined grid layouts
-        layout_configs = {
-            "1 por hoja": (1, 1),
-            "2 por hoja": (1, 2),
-            "3 por hoja (1x3)": (1, 3),
-            "4 por hoja (2x2)": (2, 2),
-            "6 por hoja (2x3)": (2, 3),
-            "9 por hoja (3x3)": (3, 3)
-        }
-        # Return the config, or a default (e.g., 1x1) if not a grid mode
-        return layout_configs.get(layout_choice, (1, 1))
-
-def calculate_mosaic_layout(image_paths, pagesize):
+# (This section is unchanged from the previous step)
+def calculate_mosaic_layout(image_paths):
     margin = 1 * cm
-    page_width, page_height = pagesize
+    page_width, page_height = A4
     bin_width = page_width - 2 * margin
     bin_height = page_height - 2 * margin
     images_data = [{'width': w, 'height': h, 'path': p}
@@ -110,12 +56,10 @@ def calculate_mosaic_layout(image_paths, pagesize):
     unpacked_paths = list(all_rids - packed_rids)
     return packer, unpacked_paths
 
-def calculate_grid_layout(image_paths):
-    rows, cols = get_grid_dimensions()
+def calculate_grid_layout(image_paths, layout_choice):
+    layout_configs = {"1 por hoja": (1, 1), "2 por hoja": (1, 2), "4 por hoja (2x2)": (2, 2), "6 por hoja (2x3)": (2, 3)}
+    rows, cols = layout_configs[layout_choice]
     chunk_size = rows * cols
-    # Handle case where chunk_size might be 0 if user enters invalid custom values
-    if chunk_size == 0:
-        return []
     pages = [image_paths[i:i + chunk_size] for i in range(0, len(image_paths), chunk_size)]
     return pages
 
@@ -133,8 +77,8 @@ def draw_preview_page():
     page_data = preview_pages[current_preview_page_index]
     layout_choice = layout_var.get()
     x0, y0, paper_w_px, paper_h_px = paper_dims['x'], paper_dims['y'], paper_dims['w'], paper_dims['h']
-    page_width_pt, page_height_pt = get_page_size()
-    scale = paper_w_px / page_width_pt
+    A4_w_pt, A4_h_pt = A4
+    scale = paper_w_px / A4_w_pt
     margin_pt = 1 * cm
 
     if layout_choice == "Mosaico (Ahorro de papel)":
@@ -155,10 +99,10 @@ def draw_preview_page():
                 preview_canvas.create_rectangle(px, py, px + pw, py + ph, outline="red", fill="pink", tags="layout_item")
                 preview_canvas.create_text(px + 4, py + 4, text=f"Error:\n{os.path.basename(rect.rid)}", anchor="nw", font=("Arial", 7), fill="red", tags="layout_item")
     else: # Grid layouts
-        rows, cols = get_grid_dimensions()
-        if rows == 0 or cols == 0: return # Avoid division by zero
-        cell_width_pt = (page_width_pt - 2 * margin_pt) / cols
-        cell_height_pt = (page_height_pt - 2 * margin_pt) / rows
+        layout_configs = {"1 por hoja": (1, 1), "2 por hoja": (1, 2), "4 por hoja (2x2)": (2, 2), "6 por hoja (2x3)": (2, 3)}
+        rows, cols = layout_configs[layout_choice]
+        cell_width_pt = (A4_w_pt - 2 * margin_pt) / cols
+        cell_height_pt = (A4_h_pt - 2 * margin_pt) / rows
         for i, path in enumerate(page_data):
             row, col = divmod(i, cols)
             x_pt = margin_pt + col * cell_width_pt
@@ -176,69 +120,51 @@ def draw_preview_page():
                 py_centered = py + (ph - img_h) / 2
                 preview_canvas.thumbnail_references.append(photo_img)
                 preview_canvas.create_image(px_centered, py_centered, image=photo_img, anchor="nw", tags="layout_item")
+
+                # Draw border for 'Ajustar' mode
+                if fit_mode_var.get() == FIT_MODE_FIT:
+                    try:
+                        border_width = int(border_width_var.get())
+                        if border_width > 0:
+                            border_color = border_color_var.get()
+                            preview_canvas.create_rectangle(
+                                px_centered, py_centered,
+                                px_centered + img_w, py_centered + img_h,
+                                outline=border_color, width=border_width, tags="layout_item"
+                            )
+                    except (ValueError, tk.TclError):
+                        pass # Ignore errors from invalid border width during typing
             except Exception as e:
                 preview_canvas.create_rectangle(px, py, px + pw, py + ph, outline="red", fill="pink", tags="layout_item")
                 preview_canvas.create_text(px + 4, py + 4, text=f"Error:\n{os.path.basename(path)}", anchor="nw", font=("Arial", 7), fill="red", tags="layout_item")
 
 def update_preview():
     """
-    Calculates the full layout and redraws the entire preview canvas.
-    This is the main function for refreshing the preview pane.
+    Calculates the full layout based on selected images and options,
+    then displays the first page of the result.
     """
-    global preview_pages, current_preview_page_index, paper_dims
+    global preview_pages, current_preview_page_index
 
-    # 0. Save current state
-    saved_page_index = current_preview_page_index
-
-    # 1. Recalculate paper dimensions and redraw paper background
-    canvas_w = preview_canvas.winfo_width()
-    canvas_h = preview_canvas.winfo_height()
-    if canvas_w <= 1 or canvas_h <= 1: # Avoids error on first launch
-        return
-
-    page_w_pt, page_h_pt = get_page_size()
-    ar = page_w_pt / page_h_pt
-
-    paper_w_px = min(canvas_w * 0.95, (canvas_h * 0.95) * ar)
-    paper_h_px = paper_w_px / ar
-    if paper_h_px > canvas_h * 0.95:
-        paper_h_px = canvas_h * 0.95
-        paper_w_px = paper_h_px * ar
-
-    x0 = (canvas_w - paper_w_px) / 2
-    y0 = (canvas_h - paper_h_px) / 2
-
-    preview_canvas.delete("all")
-    preview_canvas.create_rectangle(x0, y0, x0 + paper_w_px, y0 + paper_h_px, fill="white", tags="paper")
-    paper_dims = {'x': x0, 'y': y0, 'w': paper_w_px, 'h': paper_h_px}
-
-    # 2. Calculate layout for images
     preview_pages = []
-    if not image_paths:
-        pass
+    current_preview_page_index = 0
+
+    if not image_paths or not paper_dims:
+        preview_canvas.delete("layout_item")
     else:
         layout_choice = layout_var.get()
-        pagesize = (page_w_pt, page_h_pt)
         if layout_choice == "Mosaico (Ahorro de papel)":
             try:
-                packer, _ = calculate_mosaic_layout(image_paths, pagesize)
+                packer, _ = calculate_mosaic_layout(image_paths)
+                # A packer is an iterable of bins (pages), convert to a list of non-empty pages
                 preview_pages = [bin for bin in packer if bin]
             except Exception as e:
                 messagebox.showerror("Error de Cálculo", f"No se pudo calcular el diseño de mosaico:\n{e}")
                 preview_pages = []
         else:
-            preview_pages = calculate_grid_layout(image_paths)
+            # This function already returns a list of pages (lists of image paths)
+            preview_pages = calculate_grid_layout(image_paths, layout_choice)
 
-    # 3. Restore page index
-    new_total_pages = len(preview_pages)
-    if new_total_pages == 0:
-        current_preview_page_index = 0
-    elif saved_page_index < new_total_pages:
-        current_preview_page_index = saved_page_index
-    else:
-        current_preview_page_index = new_total_pages - 1
-
-    # 4. Draw the content for the current page and update controls
+    # Always draw the current page (even if it's empty) and update controls
     draw_preview_page()
     update_pagination_controls()
 
@@ -277,27 +203,28 @@ def generate_pdf():
     if not save_path:
         return
     try:
-        pagesize = get_page_size()
         layout_choice = layout_var.get()
         if layout_choice == "Mosaico (Ahorro de papel)":
-            packed_pages, unpacked = calculate_mosaic_layout(image_paths, pagesize)
+            packed_pages, unpacked = calculate_mosaic_layout(image_paths)
             if unpacked:
                 msg = "Imágenes omitidas por ser demasiado grandes:\n\n" + "\n".join(f"- {os.path.basename(p)}" for p in unpacked)
                 messagebox.showwarning("Imágenes Grandes Omitidas", msg)
             if not any(packed_pages):
                 messagebox.showerror("Error", "No se pudo empaquetar ninguna imagen.")
                 return
-            draw_mosaic_pdf(packed_pages, save_path, pagesize)
+            draw_mosaic_pdf(packed_pages, save_path)
         else: # Grid modes
-            pages = calculate_grid_layout(image_paths)
+            pages = calculate_grid_layout(image_paths, layout_choice)
             fit_mode = fit_mode_var.get()
-            draw_grid_pdf(pages, fit_mode, save_path, pagesize)
+            border_width = int(border_width_var.get())
+            border_color = border_color_var.get()
+            draw_grid_pdf(pages, layout_choice, fit_mode, save_path, border_width, border_color)
     except Exception as e:
         messagebox.showerror("Error", f"Ocurrió un error inesperado:\n{e}")
 
-def draw_mosaic_pdf(packer, save_path, pagesize):
+def draw_mosaic_pdf(packer, save_path):
     margin = 1 * cm
-    c = canvas.Canvas(save_path, pagesize=pagesize)
+    c = canvas.Canvas(save_path, pagesize=A4)
     for i, abin in enumerate(packer):
         if i > 0: c.showPage()
         for rect in abin:
@@ -310,13 +237,11 @@ def draw_mosaic_pdf(packer, save_path, pagesize):
     c.save()
     messagebox.showinfo("Éxito", f"PDF en modo Mosaico guardado en:\n{save_path}")
 
-def draw_grid_pdf(pages, fit_mode, save_path, pagesize):
-    rows, cols = get_grid_dimensions()
-    if rows == 0 or cols == 0:
-        messagebox.showerror("Error de Diseño", "Las filas y columnas deben ser mayores que cero.")
-        return
-    c = canvas.Canvas(save_path, pagesize=pagesize)
-    width, height = pagesize
+def draw_grid_pdf(pages, layout_choice, fit_mode, save_path, border_width, border_color):
+    layout_configs = {"1 por hoja": (1, 1), "2 por hoja": (1, 2), "4 por hoja (2x2)": (2, 2), "6 por hoja (2x3)": (2, 3)}
+    rows, cols = layout_configs[layout_choice]
+    c = canvas.Canvas(save_path, pagesize=A4)
+    width, height = A4
     margin = 1 * cm
     cell_width = (width - 2 * margin) / cols
     cell_height = (height - 2 * margin) / rows
@@ -325,31 +250,59 @@ def draw_grid_pdf(pages, fit_mode, save_path, pagesize):
         positions = [(margin + col * cell_width, margin + (rows - 1 - row) * cell_height) for row in range(rows) for col in range(cols)]
         for j, img_path in enumerate(page_chunk):
             pos_x, pos_y = positions[j]
-            if fit_mode == "Ajustar":
-                c.drawImage(ImageReader(img_path), pos_x, pos_y, width=cell_width, height=cell_height, preserveAspectRatio=True, anchor='c')
-            elif fit_mode == "Rellenar":
-                img = Image.open(img_path)
+            img = Image.open(img_path)
+
+            if fit_mode == FIT_MODE_FIT:
+                c.drawImage(ImageReader(img), pos_x, pos_y, width=cell_width, height=cell_height, preserveAspectRatio=True, anchor='c')
+                if border_width > 0:
+                    img_w, img_h = img.size
+                    cell_ar = cell_width / cell_height
+                    img_ar = img_w / img_h
+                    if img_ar > cell_ar:
+                        final_w = cell_width
+                        final_h = cell_width / img_ar
+                    else:
+                        final_h = cell_height
+                        final_w = cell_height * img_ar
+
+                    final_x = pos_x + (cell_width - final_w) / 2
+                    final_y = pos_y + (cell_height - final_h) / 2
+
+                    c.setStrokeColor(HexColor(border_color))
+                    c.setLineWidth(border_width)
+                    c.rect(final_x, final_y, final_w, final_h, stroke=1, fill=0)
+
+            elif fit_mode == FIT_MODE_FILL:
                 cropped_img = ImageOps.fit(img, (int(cell_width), int(cell_height)), method=Image.Resampling.LANCZOS)
                 c.drawImage(ImageReader(cropped_img), pos_x, pos_y, width=cell_width, height=cell_height)
     c.save()
     messagebox.showinfo("Éxito", f"PDF guardado exitosamente en:\n{save_path}")
 
 
-def handle_layout_change(event=None):
+def handle_fit_mode_change():
     """
-    Shows or hides the custom layout frame based on the combobox selection
+    Shows or hides the border options based on the fit mode selection
     and triggers a preview update.
     """
-    if layout_var.get() == "Personalizado...":
-        custom_layout_frame.grid()
+    if fit_mode_var.get() == FIT_MODE_FIT:
+        border_options_frame.grid()
     else:
-        custom_layout_frame.grid_remove()
+        border_options_frame.grid_remove()
     update_preview()
+
+def choose_border_color():
+    """
+    Opens a color chooser and updates the border color variable.
+    """
+    color_code = colorchooser.askcolor(title="Elegir color del borde")
+    if color_code and color_code[1]:
+        border_color_var.set(color_code[1])
+        update_preview()
 
 
 # --- UI Setup ---
 root = tk.Tk()
-root.title("Impresión Maestra - v1.5")
+root.title("Impresión Maestra - v1.6")
 root.geometry("1024x768")
 
 main_container = ttk.Frame(root)
@@ -383,9 +336,19 @@ next_page_button = ttk.Button(pagination_frame, text="Siguiente >", state=tk.DIS
 next_page_button.grid(row=0, column=2, sticky='w', padx=5, pady=2)
 
 def redraw_paper(event):
-    """
-    Handles canvas resize events by triggering a full preview update.
-    """
+    global paper_dims
+    preview_canvas.delete("all")
+    canvas_w, canvas_h = event.width, event.height
+    ar = 210 / 297
+    paper_w = min(canvas_w * 0.95, (canvas_h * 0.95) * ar)
+    paper_h = paper_w / ar
+    if paper_h > canvas_h * 0.95:
+        paper_h = canvas_h * 0.95
+        paper_w = paper_h * ar
+    x0 = (canvas_w - paper_w) / 2
+    y0 = (canvas_h - paper_h) / 2
+    preview_canvas.create_rectangle(x0, y0, x0 + paper_w, y0 + paper_h, fill="white", tags="paper")
+    paper_dims = {'x': x0, 'y': y0, 'w': paper_w, 'h': paper_h}
     update_preview()
 
 preview_canvas.bind("<Configure>", redraw_paper)
@@ -393,73 +356,54 @@ preview_canvas.bind("<Configure>", redraw_paper)
 options_frame = ttk.LabelFrame(controls_panel, text="Opciones de Diseño", padding=(10, 5))
 options_frame.pack(fill=tk.X, pady=5)
 
-# --- Layout Selection ---
 layout_label = ttk.Label(options_frame, text="Diseño por Hoja:")
 layout_label.grid(row=0, column=0, padx=5, pady=5, sticky="w")
 layout_var = tk.StringVar()
-layout_options = [
-    "1 por hoja", "2 por hoja", "3 por hoja (1x3)", "4 por hoja (2x2)",
-    "6 por hoja (2x3)", "9 por hoja (3x3)", "Mosaico (Ahorro de papel)", "Personalizado..."
-]
+layout_options = ["1 por hoja", "2 por hoja", "4 por hoja (2x2)", "6 por hoja (2x3)", "Mosaico (Ahorro de papel)"]
 layout_combo = ttk.Combobox(options_frame, textvariable=layout_var, values=layout_options, state="readonly")
 layout_combo.grid(row=0, column=1, padx=5, pady=5, sticky="ew")
 layout_combo.set("4 por hoja (2x2)")
-layout_combo.bind("<<ComboboxSelected>>", handle_layout_change)
 
-# --- Custom Layout Frame (Initially Hidden) ---
-custom_layout_frame = ttk.Frame(options_frame)
-custom_layout_frame.grid(row=1, column=0, columnspan=2, padx=5, pady=0, sticky="ew")
-
-rows_label = ttk.Label(custom_layout_frame, text="Filas:")
-rows_label.pack(side=tk.LEFT, padx=(5, 5))
-rows_var = tk.StringVar(value="2")
-rows_spinbox = tk.Spinbox(custom_layout_frame, from_=1, to=10, width=5, textvariable=rows_var, command=update_preview)
-rows_spinbox.pack(side=tk.LEFT, padx=(0, 10))
-
-cols_label = ttk.Label(custom_layout_frame, text="Columnas:")
-cols_label.pack(side=tk.LEFT, padx=(5, 5))
-cols_var = tk.StringVar(value="2")
-cols_spinbox = tk.Spinbox(custom_layout_frame, from_=1, to=10, width=5, textvariable=cols_var, command=update_preview)
-cols_spinbox.pack(side=tk.LEFT)
-custom_layout_frame.grid_remove() # Hide it by default
-
-# --- Fit Mode ---
 fit_mode_label = ttk.Label(options_frame, text="Modo de Ajuste:")
-fit_mode_label.grid(row=2, column=0, padx=5, pady=5, sticky="w")
-fit_mode_var = tk.StringVar(value="Ajustar")
+fit_mode_label.grid(row=1, column=0, padx=5, pady=5, sticky="w")
+fit_mode_var = tk.StringVar(value=FIT_MODE_FIT)
 fit_mode_frame = ttk.Frame(options_frame)
-fit_mode_frame.grid(row=2, column=1, padx=5, pady=5, sticky="ew")
-fit_radio_fit = ttk.Radiobutton(fit_mode_frame, text="Ajustar (con bordes)", variable=fit_mode_var, value="Ajustar", command=update_preview)
-fit_radio_fill = ttk.Radiobutton(fit_mode_frame, text="Rellenar (recorte)", variable=fit_mode_var, value="Rellenar", command=update_preview)
+fit_mode_frame.grid(row=1, column=1, padx=5, pady=5, sticky="ew")
+fit_radio_fit = ttk.Radiobutton(fit_mode_frame, text="Ajustar (con bordes)", variable=fit_mode_var, value=FIT_MODE_FIT, command=handle_fit_mode_change)
+fit_radio_fill = ttk.Radiobutton(fit_mode_frame, text="Rellenar (recorte)", variable=fit_mode_var, value=FIT_MODE_FILL, command=handle_fit_mode_change)
 fit_radio_fit.pack(side=tk.LEFT, expand=True)
 fit_radio_fill.pack(side=tk.LEFT, expand=True)
 
-# --- Orientation ---
-orientation_label = ttk.Label(options_frame, text="Orientación:")
-orientation_label.grid(row=3, column=0, padx=5, pady=5, sticky="w")
-orientation_var = tk.StringVar(value="Vertical")
-orientation_frame = ttk.Frame(options_frame)
-orientation_frame.grid(row=3, column=1, padx=5, pady=5, sticky="ew")
-orientation_radio_v = ttk.Radiobutton(orientation_frame, text="Vertical", variable=orientation_var, value="Vertical", command=update_preview)
-orientation_radio_h = ttk.Radiobutton(orientation_frame, text="Horizontal", variable=orientation_var, value="Horizontal", command=update_preview)
-orientation_radio_v.pack(side=tk.LEFT, expand=True)
-orientation_radio_h.pack(side=tk.LEFT, expand=True)
+# --- Border Options Frame (Initially Hidden) ---
+border_options_frame = ttk.Frame(options_frame)
+border_options_frame.grid(row=2, column=0, columnspan=2, padx=5, pady=0, sticky="ew")
+
+border_width_label = ttk.Label(border_options_frame, text="Grosor del Borde:")
+border_width_label.pack(side=tk.LEFT, padx=(5, 5))
+border_width_var = tk.StringVar(value="1")
+border_width_spinbox = tk.Spinbox(border_options_frame, from_=0, to=10, width=5, textvariable=border_width_var, command=update_preview)
+border_width_spinbox.pack(side=tk.LEFT, padx=(0, 10))
+
+border_color_var = tk.StringVar(value="#000000")
+border_color_button = ttk.Button(border_options_frame, text="Color del Borde", command=choose_border_color)
+border_color_button.pack(side=tk.LEFT, padx=(5,5))
+border_options_frame.grid_remove() # Hide it by default
 
 options_frame.columnconfigure(1, weight=1)
+
+# Set initial UI state
+handle_fit_mode_change()
 
 action_frame = ttk.LabelFrame(controls_panel, text="Acciones", padding=(10, 5))
 action_frame.pack(fill=tk.X, pady=5)
 
-load_button = ttk.Button(action_frame, text="Cargar Imágenes", command=upload_files_replace)
-load_button.pack(side=tk.LEFT, padx=5, pady=5, fill=tk.X, expand=True)
-
-add_button = ttk.Button(action_frame, text="Añadir Imágenes", command=upload_files_add)
-add_button.pack(side=tk.LEFT, padx=5, pady=5, fill=tk.X, expand=True)
+load_button = ttk.Button(action_frame, text="Cargar Imágenes", command=upload_files)
+load_button.pack(side=tk.LEFT, padx=5, pady=5)
 
 preview_button = ttk.Button(action_frame, text="Actualizar Previsualización", command=update_preview, state=tk.DISABLED)
-preview_button.pack(pady=5, fill=tk.X)
+preview_button.pack(side=tk.LEFT, padx=5, pady=5)
 
 generate_button = ttk.Button(action_frame, text="Generar PDF", command=generate_pdf, state=tk.DISABLED)
-generate_button.pack(pady=5, fill=tk.X)
+generate_button.pack(side=tk.LEFT, padx=5, pady=5)
 
 root.mainloop()


### PR DESCRIPTION
This commit introduces a new feature allowing users to customize the border thickness and color when using the 'Ajustar (con bordes)' (Fit with borders) mode.

Key changes:
- Added a Spinbox for border thickness (0-10) and a Button to open a color chooser in the UI.
- These new controls are only visible and active when the 'Fit' mode is selected.
- The preview canvas now accurately renders the specified border around images.
- The PDF generation logic has been updated to calculate the final image dimensions and draw a border with the correct thickness (in points) and color.
- Refactored the fit mode logic to use constants for better code quality and maintainability.
- Updated window title to v1.6.