### PR TITLE
The application was crashing on startup with a `_tkinter.TclError: wr…

### DIFF
--- a/main.py
+++ b/main.py
@@ -910,8 +910,8 @@ load_resources()
 
 # Set initial sash positions for the PanedWindow
 root.update_idletasks()
-main_paned_window.sash_place(0, 120, 0)
-main_paned_window.sash_place(1, 400, 0) # 120px for first pane + 280px for second
+main_paned_window.sashpos(0, 120)
+main_paned_window.sashpos(1, 400)
 
 action_frame = ttk.LabelFrame(controls_panel, text="Acciones", padding=(10, 5))
 action_frame.pack(fill=tk.X, pady=5)


### PR DESCRIPTION
…ong # args` when running as a packaged executable.

This was caused by using the incorrect method `sash_place` to set the initial positions of the sashes on the `ttk.PanedWindow`. The `sash_place` method was passing an incorrect number of arguments to the underlying Tcl `sashpos` command.

The fix is to use the correct `sashpos(index, position)` method, which resolves the error.